### PR TITLE
Added MQTT TLS using NetworkClientSecure and CA certificate handling

### DIFF
--- a/14_arduino/Flora2Arduino/Flora2Cfg.h
+++ b/14_arduino/Flora2Arduino/Flora2Cfg.h
@@ -82,6 +82,10 @@
 /// Enable MQTT over TLS (requires NetworkClientSecure + CA cert in LittleFS as /root_ca.pem).
 //#define MQTT_TLS_EN
 
+/// Optional TLS fallback: allow insecure TLS if /root_ca.pem cannot be loaded.
+/// Disabled by default to keep broker certificate validation enforced.
+//#define MQTT_TLS_ALLOW_INSECURE_FALLBACK
+
 /// Enable Home Assistant MQTT auto-discovery messages on connect.
 //#define HA_DISCOVERY_EN
 

--- a/14_arduino/Flora2Arduino/Flora2Cfg.h
+++ b/14_arduino/Flora2Arduino/Flora2Cfg.h
@@ -79,7 +79,7 @@
 /// Enable battery voltage measurement via ADC.
 #define BATTERY_VOLTAGE_EN
 
-/// Enable MQTT over TLS (requires WiFiClientSecure + CA cert in LittleFS as /ca.crt).
+/// Enable MQTT over TLS (requires NetworkClientSecure + CA cert in LittleFS as /root_ca.pem).
 //#define MQTT_TLS_EN
 
 /// Enable Home Assistant MQTT auto-discovery messages on connect.

--- a/14_arduino/Flora2Arduino/README_ARDUINO.md
+++ b/14_arduino/Flora2Arduino/README_ARDUINO.md
@@ -20,6 +20,10 @@ Flora2 Arduino is a C++ / Arduino port of the Flora2 plant irrigation controller
 - Arduino CLI or Arduino IDE with ESP32 board support (Arduino core 3.3.8 recommended).
 - Required libraries — see [Acknowledgements](#5-acknowledgements).
 - `data/config.json` uploaded to the board's LittleFS partition and a `secrets.h` file with WiFi and MQTT credentials.
+- Optional secure MQTT setup: set `MQTT_PORT` to `8883`, define `MQTT_TLS_EN`, and upload the broker CA certificate as `data/root_ca.pem` in LittleFS.
+
+> [!NOTE]
+> The certificate file must include `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
 
 ### Building and uploading
 
@@ -43,7 +47,8 @@ Place your `config.json` at `data/config.json` inside the sketch folder, then us
 
 - **Runtime** — `data/config.json` defines plant identities, sensor interface mode (BLE / LOCAL / MQTT), moisture thresholds, and irrigation durations. See `ConfigLoader` for the full schema.
 - **Optional stale-sensor safeguard** — `general.stale_sensor_max_age_s` controls sensor freshness for auto irrigation. `0` disables guarding; values `>0` enable it with max allowed sensor age in seconds.
-- **Compile-time** — `Flora2Cfg.h` contains hardware pin assignments and feature flags such as `WEATHER_SENSOR_ENV3` and `TEMPERATURE_SENSOR_EN`.
+- **Compile-time** — `Flora2Cfg.h` contains hardware pin assignments and feature flags such as `WEATHER_SENSOR_ENV3`, `TEMPERATURE_SENSOR_EN`, and `MQTT_TLS_EN`.
+- **MQTT transport** — plain MQTT uses the broker port configured in `secrets.h` (commonly `1883`). For TLS, enable `MQTT_TLS_EN`, set `MQTT_PORT` to `8883`, and provide `data/root_ca.pem` so `MqttManager` can validate the broker certificate.
 - **Default PCB wiring note** — moisture sensor 2 input and battery voltage ADC are both routed to GPIO 35 on the default Flora2 hardware. Changing either signal to a different GPIO requires a PCB hardware patch.
 - **Timezone / DST** — `TIMEZONE_STR` in `Flora2Cfg.h` sets the POSIX timezone string (e.g. `"CET-1CEST,M3.5.0,M10.5.0/3"`). Edit it to match your location before compiling.
 

--- a/14_arduino/Flora2Arduino/README_ARDUINO.md
+++ b/14_arduino/Flora2Arduino/README_ARDUINO.md
@@ -21,6 +21,7 @@ Flora2 Arduino is a C++ / Arduino port of the Flora2 plant irrigation controller
 - Required libraries — see [Acknowledgements](#5-acknowledgements).
 - `data/config.json` uploaded to the board's LittleFS partition and a `secrets.h` file with WiFi and MQTT credentials.
 - Optional secure MQTT setup: set `MQTT_PORT` to `8883`, define `MQTT_TLS_EN`, and upload the broker CA certificate as `data/root_ca.pem` in LittleFS.
+- Optional (not recommended): define `MQTT_TLS_ALLOW_INSECURE_FALLBACK` to allow insecure TLS only when loading `root_ca.pem` fails.
 
 > [!NOTE]
 > The certificate file must include `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
@@ -48,7 +49,7 @@ Place your `config.json` at `data/config.json` inside the sketch folder, then us
 - **Runtime** — `data/config.json` defines plant identities, sensor interface mode (BLE / LOCAL / MQTT), moisture thresholds, and irrigation durations. See `ConfigLoader` for the full schema.
 - **Optional stale-sensor safeguard** — `general.stale_sensor_max_age_s` controls sensor freshness for auto irrigation. `0` disables guarding; values `>0` enable it with max allowed sensor age in seconds.
 - **Compile-time** — `Flora2Cfg.h` contains hardware pin assignments and feature flags such as `WEATHER_SENSOR_ENV3`, `TEMPERATURE_SENSOR_EN`, and `MQTT_TLS_EN`.
-- **MQTT transport** — plain MQTT uses the broker port configured in `secrets.h` (commonly `1883`). For TLS, enable `MQTT_TLS_EN`, set `MQTT_PORT` to `8883`, and provide `data/root_ca.pem` so `MqttManager` can validate the broker certificate.
+- **MQTT transport** — plain MQTT uses the broker port configured in `secrets.h` (commonly `1883`). For TLS, enable `MQTT_TLS_EN`, set `MQTT_PORT` to `8883`, and provide `data/root_ca.pem` so `MqttManager` can validate the broker certificate. If you explicitly define `MQTT_TLS_ALLOW_INSECURE_FALLBACK`, the sketch can fall back to insecure TLS when CA loading fails.
 - **Default PCB wiring note** — moisture sensor 2 input and battery voltage ADC are both routed to GPIO 35 on the default Flora2 hardware. Changing either signal to a different GPIO requires a PCB hardware patch.
 - **Timezone / DST** — `TIMEZONE_STR` in `Flora2Cfg.h` sets the POSIX timezone string (e.g. `"CET-1CEST,M3.5.0,M10.5.0/3"`). Edit it to match your location before compiling.
 

--- a/14_arduino/Flora2Arduino/secrets.h.example
+++ b/14_arduino/Flora2Arduino/secrets.h.example
@@ -18,7 +18,8 @@ static const uint8_t NUM_WIFI_NETWORKS =
 // MQTT broker credentials
 // Use port 1883 for plain MQTT. For TLS, set MQTT_PORT to 8883, define
 // MQTT_TLS_EN in Flora2Cfg.h, and upload the broker CA cert as
-// data/root_ca.pem in LittleFS.
+// data/root_ca.pem in LittleFS. Optional (not recommended): define
+// MQTT_TLS_ALLOW_INSECURE_FALLBACK to permit insecure TLS when CA loading fails.
 #define MQTT_HOST       "your.mqtt.broker.example.com"
 #define MQTT_PORT       1883
 #define MQTT_USERNAME   "your_mqtt_user"

--- a/14_arduino/Flora2Arduino/secrets.h.example
+++ b/14_arduino/Flora2Arduino/secrets.h.example
@@ -16,6 +16,9 @@ static const uint8_t NUM_WIFI_NETWORKS =
     sizeof(WIFI_NETWORKS) / sizeof(WIFI_NETWORKS[0]);
 
 // MQTT broker credentials
+// Use port 1883 for plain MQTT. For TLS, set MQTT_PORT to 8883, define
+// MQTT_TLS_EN in Flora2Cfg.h, and upload the broker CA cert as
+// data/root_ca.pem in LittleFS.
 #define MQTT_HOST       "your.mqtt.broker.example.com"
 #define MQTT_PORT       1883
 #define MQTT_USERNAME   "your_mqtt_user"

--- a/14_arduino/Flora2Arduino/src/MqttManager.cpp
+++ b/14_arduino/Flora2Arduino/src/MqttManager.cpp
@@ -6,6 +6,7 @@
 
 #include "MqttManager.h"
 #include <ArduinoJson.h>
+#include <LittleFS.h>
 #include "../secrets.h"
 #include "../Flora2Cfg.h"
 
@@ -57,7 +58,12 @@ MqttManager::MqttManager(const AppConfig& cfg)
 bool MqttManager::connect()
 {
 #ifdef MQTT_TLS_EN
-    _net.setInsecure();  // Or use _net.setCACert(ca_cert) if CA cert is available
+    File f = LittleFS.open("/root_ca.pem", "r");
+    if (!f || !_net.loadCACert(f, f.size())) {
+        log_e("%s: Failed to load CA cert", TAG);
+        _net.setInsecure();
+    }
+    if (f) f.close();
 #endif
 
     _client.begin(MQTT_HOST, MQTT_PORT, _net);

--- a/14_arduino/Flora2Arduino/src/MqttManager.cpp
+++ b/14_arduino/Flora2Arduino/src/MqttManager.cpp
@@ -61,7 +61,13 @@ bool MqttManager::connect()
     File f = LittleFS.open("/root_ca.pem", "r");
     if (!f || !_net.loadCACert(f, f.size())) {
         log_e("%s: Failed to load CA cert", TAG);
+#ifdef MQTT_TLS_ALLOW_INSECURE_FALLBACK
+        log_w("%s: MQTT_TLS_ALLOW_INSECURE_FALLBACK enabled; using insecure TLS", TAG);
         _net.setInsecure();
+#else
+        if (f) f.close();
+        return false;
+#endif
     }
     if (f) f.close();
 #endif

--- a/14_arduino/Flora2Arduino/src/MqttManager.h
+++ b/14_arduino/Flora2Arduino/src/MqttManager.h
@@ -26,8 +26,9 @@
 #pragma once
 #include <Arduino.h>
 #include <MQTT.h>
+#include "../Flora2Cfg.h"
 #ifdef MQTT_TLS_EN
-  #include <WiFiClientSecure.h>
+  #include <NetworkClientSecure.h>
 #else
   #include <WiFiClient.h>
 #endif
@@ -91,14 +92,14 @@ public:
     bool            mqttSensorUpdated[MAX_PLANT_SENSORS];
 
 private:
-    const AppConfig& _cfg;
+    const AppConfig&    _cfg;
 
 #ifdef MQTT_TLS_EN
-    WiFiClientSecure _net;
+    NetworkClientSecure _net;
 #else
-    WiFiClient       _net;
+    WiFiClient          _net;
 #endif
-    MQTTClient       _client;
+    MQTTClient          _client;
 
     char _clientId[32];
 


### PR DESCRIPTION
This PR adds optional MQTT-over-TLS support to the Arduino/ESP32 sketch by switching to `NetworkClientSecure` and loading a broker CA certificate from LittleFS for broker certificate validation.

It also refines TLS failure behavior based on review feedback:

- Adds a new compile-time option `MQTT_TLS_ALLOW_INSECURE_FALLBACK` (default: disabled).
- When `MQTT_TLS_EN` is enabled and CA loading from `/root_ca.pem` fails:
  - default behavior: MQTT connection fails (no insecure downgrade),
  - optional behavior: insecure TLS is allowed only if `MQTT_TLS_ALLOW_INSECURE_FALLBACK` is explicitly defined.
- Updates Arduino documentation/examples (`README_ARDUINO.md`, `secrets.h.example`, `Flora2Cfg.h`) to document the new flag and secure-by-default behavior.